### PR TITLE
Fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,16 @@ setup(
     long_description=readme,
     long_description_content_type='text/x-rst',
     include_package_data=True,
-    install_requires=['aiohttp','aiodns','orjson','typing_extensions','psutil','durations_nlp','rust_requests','fast_string_match'],
+    install_requires=[
+        'aiohttp',
+        'aiodns',
+        'orjson',
+        'typing_extensions',
+        'psutil',
+        'durations_nlp',
+        # 'rust_requests',
+        'fast_string_match'
+    ],
     extras_require=extras_require,
     download_url='https://github.com/cop-discord/disdick/archive/refs/tags/2.4.1.tar.gz',
     python_requires='>=3.8.0',


### PR DESCRIPTION
Comment out `rust_requests` for now, as it may cause installation errors for people without Rust/Cargo installed on their system.